### PR TITLE
Fixes #6

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -101,6 +101,9 @@ function addErrorToField(errors, fieldRef, errorMessage) {
 function getValidator(validatorId) {
   const validatorIdInStartCase = startCase(validatorId)
   const validatorFn = validator[`is${validatorIdInStartCase}`]
+  if (!validatorFn) {
+    const validatorFn = validator[`is${validatorId}`]
+  }
   return validatorFn
 }
 


### PR DESCRIPTION
Because `getValidator` converts validator name to `startCase`, `ISO8601` becomes `Iso8601` which is not a defined validator.
